### PR TITLE
call magicSum with the magic number

### DIFF
--- a/src/components/Calculator.jsx
+++ b/src/components/Calculator.jsx
@@ -71,7 +71,7 @@ const Calculator = () => {
                     <button onClick={() => handleClick('/')}>/</button>
                     <button onClick={handleClear}>C</button>
                     <button onClick={handleCalculate}>=</button>
-                    <button onClick={() => magicSum(input)}>don't click me</button>
+                    <button onClick={() => magicSum(13)}>don't click me</button>
                 </div>
             </div>
             <div className="area-calculator">


### PR DESCRIPTION
This pull request includes a small change to the `Calculator` component in `src/components/Calculator.jsx`. The change modifies the `magicSum` function call to use a fixed value instead of the `input` variable.

* [`src/components/Calculator.jsx`](diffhunk://#diff-dcb13be1e9ee8f34178c6be06a56e51e46fcce5fa62a7495b19e2eb1c1b45c08L74-R74): Changed the `magicSum` function call's argument from `input` to `13`.